### PR TITLE
Fix cache dependency path in GitHub actions

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -22,8 +22,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            '**/setup.cfg'
-            '**/pyproject.toml'
+            setup.cfg
+            pyproject.toml
       - 
         name: Get version
         id: version

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -22,8 +22,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            'setup.cfg'
-            'pyproject.toml'
+            '**/setup.cfg'
+            '**/pyproject.toml'
       - 
         name: Get version
         id: version

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: |
+            'setup.cfg'
+            'pyproject.toml'
       - 
         name: Get version
         id: version

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,8 +22,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            '**/setup.cfg'
-            '**/pyproject.toml'
+            setup.cfg
+            pyproject.toml
       - 
         name: Install Dependencies
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,8 +22,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: |
-            'setup.cfg'
-            'pyproject.toml'
+            '**/setup.cfg'
+            '**/pyproject.toml'
       - 
         name: Install Dependencies
         run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+          cache-dependency-path: |
+            'setup.cfg'
+            'pyproject.toml'
       - 
         name: Install Dependencies
         run: |


### PR DESCRIPTION
This fixes an error in the setup-python step where it fails to find a `requirements.txt` file to cache dependencies.