### PR TITLE
Feature: Update APIs

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.13"]
     steps:
       -
         name: Checkout
@@ -48,24 +48,24 @@ jobs:
       # these could be a separate job, but they require the version step
       - 
         name: Publish to PyPI
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
       -
         name: Set up Docker Buildx
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.13'
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -91,7 +91,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.13
         cache: pip
         cache-dependency-path: |
           pyproject.toml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
       - 
         name: Run Lint
         run: |
-          pylint spydertop ${{ matrix.python-version == "3.8" && "--disable=unknown-option-value" || "" }}
+          pylint spydertop ${{ matrix.python-version == '3.8' && '--disable=unknown-option-value' || '' }}
       - 
         name: Run Type Check
         uses: jakebailey/pyright-action@v1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.13"]
     steps:
       -
         name: Checkout

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
       - 
         name: Run Lint
         run: |
-          pylint spydertop
+          pylint spydertop ${{ matrix.python-version == "3.8" && "--disable=unknown-option-value" || "" }}
       - 
         name: Run Type Check
         uses: jakebailey/pyright-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,14 @@
 repos:
-  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+-   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
     rev: v0.6.1
     hooks:
-      - id: pre-commit-update
-  - repo: https://github.com/spyderbat/spyder-scan
+    -   id: pre-commit-update
+-   repo: https://github.com/spyderbat/spyder-scan
     rev: v1.1.1
     hooks:
-      - id: spyder-scan
-  - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.5
+    -   id: spyder-scan
+-   repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.88.6
     hooks:
-      - id: trufflehog
+    -   id: trufflehog
         entry: trufflehog git file://. --since-commit HEAD --no-verification --fail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
     -   id: spyder-scan
 -   repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.88.6
+    rev: 3.88.13
     hooks:
     -   id: trufflehog
         entry: trufflehog git file://. --since-commit HEAD --no-verification --fail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,9 @@ repos:
     hooks:
     -   id: trufflehog
         entry: trufflehog git file://. --since-commit HEAD --no-verification --fail
+-   repo: local
+    hooks:
+    -   id: check-black
+        name: Check black
+        entry: ./black.sh
+        language: script

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
+    rev: v0.6.1
+    hooks:
+      - id: pre-commit-update
+  - repo: https://github.com/spyderbat/spyder-scan
+    rev: v1.1.1
+    hooks:
+      - id: spyder-scan
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.88.5
+    hooks:
+      - id: trufflehog
+        entry: trufflehog git file://. --since-commit HEAD --no-verification --fail

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,22 @@
 repos:
--   repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.6.1
+-   repo: local
     hooks:
-    -   id: pre-commit-update
+      - id: check-black
+        name: Check black
+        entry: black
+        language: system
+        files: '.*\.py$'
 -   repo: https://github.com/spyderbat/spyder-scan
     rev: v1.1.1
     hooks:
-    -   id: spyder-scan
--   repo: https://github.com/trufflesecurity/trufflehog
-    rev: 3.88.13
-    hooks:
-    -   id: trufflehog
-        entry: trufflehog git file://. --since-commit HEAD --no-verification --fail
+      - id: spyder-scan
+        pass_filenames: false
 -   repo: local
     hooks:
-    -   id: check-black
-        name: Check black
-        entry: ./black.sh
-        language: script
+      - id: trufflehog
+        name: TruffleHog
+        description: Detect secrets in your data.
+        entry: bash -c 'docker run -v "$(pwd):/workdir" ghcr.io/trufflesecurity/trufflehog:latest --no-verification git file:///workdir --debug --fail --since-commit HEAD'               
+        language: system
+        stages: ["pre-commit", "pre-push"]
+        pass_filenames: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine as build
+FROM python:3-alpine AS build
 
 RUN apk add --no-cache git
 
@@ -6,6 +6,7 @@ RUN apk add --no-cache git
 # this is necessary to remove the pillow dependency
 # see https://github.com/peterbrittain/asciimatics/issues/95
 WORKDIR /
+RUN pip install setuptools
 RUN git clone https://github.com/peterbrittain/asciimatics.git && \
     cd asciimatics && \
     rm asciimatics/renderers/images.py && \

--- a/README.md
+++ b/README.md
@@ -122,6 +122,14 @@ In the virtual environment, after editing and saving a file, the `spydertop` com
 
 See the [Project Structure](https://github.com/spyderbat/spydertop/blob/main/structure.md) for a walk through of Spydertop's code base.
 
+### PR Linting
+
+To run the equivalent of the automated GitHub actions checks, run this command:
+
+```sh
+pyright --pythonversion 3.13 && pyright --pythonversion 3.8 && pylint spydertop
+```
+
 ## Debugging
 
 If you are using VSCode, `launch.json` is configured to run Spydertop with the python extension's debugger. This runs the module as a python file instead of through the command line, so command line arguments can be added in `__init__.py`.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ See the [Project Structure](https://github.com/spyderbat/spydertop/blob/main/str
 To run the equivalent of the automated GitHub actions checks, run this command:
 
 ```sh
-pyright --pythonversion 3.13 && pyright --pythonversion 3.8 && pylint spydertop
+./black.sh && pyright --pythonversion 3.13 && pyright --pythonversion 3.8 && pylint spydertop
 ```
 
 ## Debugging

--- a/black.sh
+++ b/black.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-black .

--- a/black.sh
+++ b/black.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+black .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ["spydertop"]
 include = ["spydertop"]
 platform = "All"
 useLibraryCodeForTypes = true
-# pythonVersion = "3.7"
+# pythonVersion = "3.8"
 
 [tool.pylint.typecheck]
 generated-members = ["orjson.*"]
@@ -20,7 +20,7 @@ generated-members = ["orjson.*"]
 name = "spydertop"
 description = "A tool that provides htop-like functionality for any point in time."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = { file = "LICENSE" }
 authors = [{ name = "Griffith Thomas", email = "dev@spyderbat.com" }]
 maintainers = [{ name = "Spyderbat", email = "dev@spyderbat.com" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "platformdirs",
     "urllib3",
     "orjson",
-    "importlib-metadata >= 1.0; python_version < \"3.8\"",
 ]
 dynamic = ["version"]
 

--- a/spydertop/__init__.py
+++ b/spydertop/__init__.py
@@ -6,10 +6,10 @@
 #
 
 """
-    Spydertop Historical TOP Tool
+Spydertop Historical TOP Tool
 
-    Provides a way to view the state of a system
-    in the past, utilizing the spyderbat apis.
+Provides a way to view the state of a system
+in the past, utilizing the spyderbat apis.
 """
 
 # see the cli function in cli.py for the entry point

--- a/spydertop/cli.py
+++ b/spydertop/cli.py
@@ -326,7 +326,7 @@ fetching records from the production Spyderbat API",
 )
 @click.argument("timestamp", type=Timestamp(), required=False)
 @click.pass_context
-def load(  # pylint: disable=too-many-arguments
+def load(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     ctx: click.Context,
     organization: Optional[str],
     machine: Optional[str],
@@ -482,7 +482,7 @@ def get_context(ctx: click.Context, name: Optional[str] = None):
     type=ContextParam(),
 )
 @click.pass_context
-def set_context(  # pylint: disable=too-many-arguments
+def set_context(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     ctx: click.Context,
     secret: Optional[str],
     name: str,

--- a/spydertop/cli.py
+++ b/spydertop/cli.py
@@ -300,7 +300,7 @@ Defaults to the values set in your spyderbat_api config",
     "--machine",
     "-m",
     type=str,
-    help="The machine ID to pull data from. This should be in the format 'mach:aEdYih-4bia'. \
+    help="The machine ID to pull data from. This should be in the format 'mach:aEdYh-4bia'. \
 Defaults to the values set in your spyderbat_api config",
 )
 @click.option(

--- a/spydertop/constants/columns.py
+++ b/spydertop/constants/columns.py
@@ -676,15 +676,19 @@ def format_container_status(m: AppModel, _c: Record, state: dict) -> str:
         finished = datetime.fromisoformat(values["finishedAt"])
         since_finished = (m.state.time - finished).total_seconds()
         if since_finished < 0:
-            return f"Up {pretty_time((
-                        m.state.time -
-                        datetime.fromisoformat(values['startedAt'])).total_seconds())}"
+            formatted_time = pretty_time(
+                (
+                    m.state.time - datetime.fromisoformat(values["startedAt"])
+                ).total_seconds()
+            )
+            return f"Up {formatted_time}"
         return f"{values['reason']} {pretty_time(since_finished)} ago"
     if "running" in state:
         values = state["running"]
-        return f"Up {pretty_time((
-                    m.state.time -
-                    datetime.fromisoformat(values['startedAt'])).total_seconds())}"
+        formatted_time = pretty_time(
+            (m.state.time - datetime.fromisoformat(values["startedAt"])).total_seconds()
+        )
+        return f"Up {formatted_time}"
 
     return "?"
 

--- a/spydertop/constants/columns.py
+++ b/spydertop/constants/columns.py
@@ -726,9 +726,9 @@ CONTAINER_COLUMNS = [
     Column(
         "PORTS",
         12,
-        list,
+        dict,
         field="port_bindings",
-        value_formatter=lambda m, c, x: ", ".join(x),
+        value_formatter=lambda m, c, x: ", ".join(f"{k}:{v}" for k, v in x.items()),
     ),
     Column(
         "VOLUMES",

--- a/spydertop/constants/columns.py
+++ b/spydertop/constants/columns.py
@@ -79,7 +79,13 @@ class Column:
                 else None
             )
         else:
-            self.value_getter = value_getter or (lambda m, r: value_type(r[str_field]))
+            self.value_getter = value_getter or (
+                lambda m, r: (
+                    value_type(r.get(str_field))
+                    if r is not None and str_field in r
+                    else None
+                )
+            )
         self.value_formatter = value_formatter or (lambda m, r, v: str(v))
 
     def get_value(self, model: AppModel, record: Record) -> Any:
@@ -604,7 +610,7 @@ def get_system(model: AppModel, cont: Record) -> Optional[str]:
 def format_mounts(_m: AppModel, _c: Record, mounts: List[Record]) -> str:
     """Format the mounts for a container."""
     return "\n".join(
-        f"{m['Source']}:{m['Destination']}"
+        f"{m['source']}:{m['Destination']}"
         for m in sorted(mounts, key=lambda m: m["Destination"])
     )
 

--- a/spydertop/constants/columns.py
+++ b/spydertop/constants/columns.py
@@ -13,7 +13,17 @@ The Column class is used to define the columns that are displayed in the table.
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Type, Callable, TYPE_CHECKING, Union, SupportsFloat
+from typing import (
+    Any,
+    Dict,
+    List,
+    Optional,
+    Type,
+    Callable,
+    TYPE_CHECKING,
+    Union,
+    SupportsFloat,
+)
 
 import orjson
 

--- a/spydertop/constants/columns.py
+++ b/spydertop/constants/columns.py
@@ -72,7 +72,7 @@ class Column:
         str_field: str = field or name.lower()
         if value_type is datetime:
 
-            def default_date_getter(m: AppModel, r: Record | None):
+            def default_date_getter(m: AppModel, r: Union[Record, None]):
                 value = r.get(str_field) if r is not None else None
                 if not isinstance(value, SupportsFloat):
                     return None
@@ -83,7 +83,7 @@ class Column:
             self.value_getter = value_getter or default_date_getter
         else:
 
-            def default_getter(_, r: Record | None):
+            def default_getter(_, r: Union[Record, None]):
                 return r.get(str_field) if r is not None else None
 
             self.value_getter = value_getter or default_getter

--- a/spydertop/constants/columns.py
+++ b/spydertop/constants/columns.py
@@ -217,6 +217,7 @@ def get_resource_record(
 
 
 def format_flag_counts(_m, _p, count: int) -> str:
+    """Formats flag counts with relative colors"""
     if count == 0:
         return "${8,1}0"
     if count < 5:
@@ -675,11 +676,15 @@ def format_container_status(m: AppModel, _c: Record, state: dict) -> str:
         finished = datetime.fromisoformat(values["finishedAt"])
         since_finished = (m.state.time - finished).total_seconds()
         if since_finished < 0:
-            return f"Up {pretty_time((m.state.time - datetime.fromisoformat(values['startedAt'])).total_seconds())}"
+            return f"Up {pretty_time((
+                        m.state.time -
+                        datetime.fromisoformat(values['startedAt'])).total_seconds())}"
         return f"{values['reason']} {pretty_time(since_finished)} ago"
     if "running" in state:
         values = state["running"]
-        return f"Up {pretty_time((m.state.time - datetime.fromisoformat(values['startedAt'])).total_seconds())}"
+        return f"Up {pretty_time((
+                    m.state.time -
+                    datetime.fromisoformat(values['startedAt'])).total_seconds())}"
 
     return "?"
 

--- a/spydertop/constants/columns.py
+++ b/spydertop/constants/columns.py
@@ -12,9 +12,8 @@ the cells inside of the records table.
 The Column class is used to define the columns that are displayed in the table.
 """
 
-from _typeshed import ConvertibleToFloat
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Type, Callable, TYPE_CHECKING, Union
+from typing import Any, Dict, List, Optional, Type, Callable, TYPE_CHECKING, Union, SupportsFloat
 
 import orjson
 
@@ -50,7 +49,7 @@ class Column:
     value_getter: Callable[[AppModel, Record], Any]
     value_formatter: Callable[[AppModel, Record, Any], str]
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         name: str,
         max_width: int,
@@ -75,7 +74,7 @@ class Column:
 
             def default_date_getter(m: AppModel, r: Record | None):
                 value = r.get(str_field) if r is not None else None
-                if not isinstance(value, ConvertibleToFloat):
+                if not isinstance(value, SupportsFloat):
                     return None
                 return datetime.fromtimestamp(float(value), timezone.utc).astimezone(
                     get_timezone(m.settings)
@@ -424,8 +423,8 @@ SESSION_COLUMNS = [
         value_getter=lambda m, s: (
             timedelta(seconds=m.timestamp - s["valid_from"])  # type:ignore
             if s["expire_at"] > m.timestamp  # type:ignore
-            else timedelta(seconds=s["expire_at"] - s["valid_from"])
-        ),  # type:ignore
+            else timedelta(seconds=s["expire_at"] - s["valid_from"])  # type:ignore
+        ),
         value_formatter=lambda m, s, x: pretty_time(x.total_seconds()),
     ),
     Column("LEADPID", 7, int, field="pid"),
@@ -458,8 +457,8 @@ CONNECTION_COLUMNS = [
             if "duration" not in c
             or "valid_to" not in c
             or c["valid_to"] > m.timestamp  # type:ignore
-            else timedelta(seconds=c["duration"])
-        ),  # type:ignore
+            else timedelta(seconds=c["duration"])  # type:ignore
+        ),
         value_formatter=lambda m, c, x: pretty_time(x.total_seconds()),
     ),
     Column("TXPACK", 6, int, field="packets_tx", enabled=False),
@@ -486,8 +485,8 @@ CONNECTION_COLUMNS = [
         align=Alignment.RIGHT,
         value_getter=lambda m, c: f'{c["local_ip"]}:{c["local_port"]}',
         value_formatter=lambda m, c, x: pretty_address(
-            c["local_ip"], c["local_port"]
-        ),  # type:ignore
+            c["local_ip"], c["local_port"]  # type:ignore
+        ),
     ),
     Column(
         "DIR",
@@ -539,8 +538,8 @@ FLAG_COLUMNS = [
         timedelta,
         align=Alignment.RIGHT,
         value_getter=lambda m, f: timedelta(
-            seconds=m.timestamp - f["time"]
-        ),  # type:ignore
+            seconds=m.timestamp - f["time"]  # type:ignore
+        ),
         value_formatter=lambda m, f, x: pretty_time(x.total_seconds()),
     ),
     Column(
@@ -604,8 +603,8 @@ LISTENING_SOCKET_COLUMNS = [
         align=Alignment.RIGHT,
         value_getter=lambda m, l: f'{l["local_ip"]}:{l["local_port"]}',
         value_formatter=lambda m, l, x: pretty_address(
-            l["local_ip"], l["local_port"]
-        ),  # type:ignore
+            l["local_ip"], l["local_port"]  # type:ignore
+        ),
     ),
     Column("PUID", 20, str, enabled=False),
     Column("PROCESS", 0, str, field="proc_name"),

--- a/spydertop/model.py
+++ b/spydertop/model.py
@@ -203,7 +203,7 @@ class AppModel:  # pylint: disable=too-many-instance-attributes,too-many-public-
                 self.thread = thread
                 return
 
-            # FIXME: disabling this for now since it blocks the UI; there is no
+            # FIX: disabling this for now since it blocks the UI; there is no
             # point in loading pre-emptively if it isn't done in the background
             # # pre-emptively load more records if we're close to the end
             # if (
@@ -282,7 +282,7 @@ not enough information could be loaded.\
                 log.traceback(exc)
         return self._record_pool.orgs
 
-    def get_sources(  # pylint: disable=too-many-arguments
+    def get_sources(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         org_uid: str,
         page: Optional[int] = None,

--- a/spydertop/model.py
+++ b/spydertop/model.py
@@ -89,7 +89,6 @@ class AppModel:  # pylint: disable=too-many-instance-attributes,too-many-public-
         """Close the model, cleaning up any resources"""
         if self.thread and self.thread != threading.current_thread():
             self.thread.join()
-        self._record_pool.close()
 
     def init(self, start_duration: Optional[timedelta]) -> None:
         """Initialize the model, loading data from the source. Requires config to be complete"""

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -18,6 +18,7 @@ from datetime import timedelta
 import gzip
 import multiprocessing
 from typing import DefaultDict, Dict, List, Optional, TextIO, Union
+import time
 
 import orjson
 import urllib3
@@ -62,13 +63,144 @@ class RecordPool:
         if isinstance(self.input_, Secret) and self._connection_pool is None:
             self._connection_pool = urllib3.PoolManager()
 
-    def __del__(self):
-        self.close()
+    # somehow this is getting called when there is still an active record pool
+    # def __del__(self):
+    #     self.close()
 
     def close(self):
         """Close the record pool"""
-        if not isinstance(self._output, Secret) and self._output is not None:
+        if self._output is not None:
             self._output.close()
+            self._output = None
+
+    def _call_objects(
+        self,
+        ids: list[str],
+        org_uid: str,
+        retry: bool=True,
+    ) -> List[Record]:
+        """
+        Calls the objects service to hydrate the given ids into records
+        """
+        if len(ids) == 0:
+            return []
+        objects_response = self.guard_api_call(
+            method="POST",
+            url=f"/api/v1/org/{org_uid}/objects/",
+            ids=ids,
+        )
+        objects_response = orjson.loads(objects_response)
+        results = objects_response.get("results", [])
+        errors = objects_response.get("err_array", [])
+        to_retry = objects_response.get("retryable", [])
+        if len(errors) > 0:
+            log.warn(f"Failed to fetch these objects: {errors}")
+        if retry and len(to_retry) > 0:
+            results.extend(self._call_objects(to_retry, org_uid, retry=False))
+        return results
+
+    def _call_walk(
+        self,
+        ids: List[str],
+        rules: List[Dict[str, Union[str, int]]],
+        org_uid: str,
+    ) -> List[Record]:
+        """
+        Calls the graph walk API to find all records linked to then
+        given IDs using `rules`
+        """
+        if len(ids) == 0:
+            return []
+        objects_response = self.guard_api_call(
+            method="POST",
+            url=f"/api/v1/org/{org_uid}/objects/walk-graph",
+            ids=ids,
+            rules=rules,
+        )
+        results = list(
+            orjson.loads(line)
+            for line in objects_response.split(b"\n")
+            if len(line) > 0
+        )
+        return results
+
+    def _call_search(
+        self,
+        schema: str,
+        start_time: float,
+        end_time: float,
+        org_uid: str,
+        query: str,
+        muid: str | None = None,
+        cluster_uid: str | None = None,
+    ) -> List[Record]:
+        """
+        Calls the search API, then fetches the full records from objects,
+        using graph walking if necessary to ensure all records requried
+        to make a tree view are loaded.
+        """
+        start_time = int(start_time)
+        end_time = int(end_time)
+        search_result = self.guard_api_call(
+            method="POST",
+            url=f"/api/v1/org/{org_uid}/search",
+            start_time=start_time,
+            end_time=end_time,
+            query=query,
+            schema=schema,
+            muid=muid,
+            cluster_uid=cluster_uid,
+        )
+        search_obj = orjson.loads(search_result)
+        if "error" in search_obj:
+            log.err(
+                f"Error received from search (schema: {schema}, query: {query}):",
+                search_obj,
+            )
+            raise APIError("Searching for records failed")
+        id = search_obj.get("id")
+        if not id:
+            raise APIError("Search returned an invalid ID")
+        complete = False
+        result_ids: List[str] = []
+        token = None
+        while not complete:
+            search_page = self.guard_api_call(
+                method="POST", url=f"/api/v1/org/{org_uid}/search/{id}", token=token
+            )
+            search_page = orjson.loads(search_page)
+            if "status" in search_page:
+                if search_page["status"] == "still running":
+                    time.sleep(1)
+                    continue
+                if "Failed" in search_page["status"]:
+                    log.err("Search failed:", search_page.get("athena error"))
+                    if search_page.get("retry"):
+                        return self._call_search(
+                            schema, start_time, end_time, org_uid, query
+                        )
+                    raise APIError("Searching for records failed")
+                raise APIError("Search returned an unknown status")
+            result_ids.extend(x["id"] for x in search_page.get("results", []))
+            token = search_page.get("token")
+            if not token:
+                complete = True
+        # get records from objects
+        if len(result_ids) == 0:
+            log.debug(
+                f"Received no results from search (schema: {schema}, query: {query}, id: {id})"
+            )
+        if schema == "model_process":
+            # we want to ensure we have the full graph, so we need to walk up the parents list
+            walk_rules: List[Dict[str, Union[str, int]]] = [
+                {
+                    "field": "ppuid",
+                    "object_schema": "model_process",
+                }
+            ]
+            return self._call_walk(result_ids, walk_rules, org_uid)
+
+        return self._call_objects(result_ids, org_uid)
 
     def load_api(  # pylint: disable=too-many-arguments
         self,
@@ -76,7 +208,7 @@ class RecordPool:
         source_uid: str,
         timestamp: float,
         duration: timedelta,
-        before=timedelta(seconds=120),
+        before=timedelta(seconds=300),
     ):
         """Load data from the source, either the API or a file, then process it"""
         log.info(f"Loading data for time: {timestamp} and duration: {duration}")
@@ -102,34 +234,43 @@ class RecordPool:
         )
 
         if source_uid.startswith("clus:"):
+            cluster_uid = source_uid
             # this is a cluster, so we need to get the k8s data
             # and then query each node
-            log.info("Loading cluster data")
-            k8s_data = self.guard_api_call(
-                method="POST",
-                url="/api/v1/source/query/",
-                **input_data,
-                src_uid=f"{source_uid}_base",
-                data_type="k8s",
-            )
-            log.info("Parsing cluster data")
-            self._process_records(k8s_data.split(b"\n"), 0.1, parallel=False)
+            if len(self.records["model_k8s_node"]) == 0:
+                log.info("Loading cluster data")
+                node_data = self._call_search(
+                    **input_data,
+                    query=f"cluster_uid = '{source_uid}'",
+                    schema="model_k8s_node",
+                )
+                log.info("Parsing cluster data")
+                self._process_records(node_data, 0.1, parallel=False)
             log.info("Loading node data")
-            sources = [node["muid"] for node in self.records["model_k8s_node"].values()]
+            sources = [
+                str(node["muid"])
+                for node in self.records["model_k8s_node"].values()
+                if "muid" in node
+            ]
         else:
+            cluster_uid = None
             self.progress = 0.1
             log.info("Loading machine data")
             sources = [source_uid]
 
-        def call_api(data_type: str, src_id: str):
-            ndjson = self.guard_api_call(
-                method="POST",
-                url="/api/v1/source/query/",
+        def call_api(schema: str, src_id: str):
+            records = self._call_search(
                 **input_data,
-                src_uid=src_id,
-                data_type=data_type,
+                query=f"*",
+                muid=src_id,
+                cluster_uid=cluster_uid,
+                schema=schema,
             )
-            return ndjson.split(b"\n")
+            return records
+
+        def fetch_machines(muids: List[str]) -> List[Record]:
+            muids = [m for m in muids if m not in self.records["model_machine"]]
+            return self._call_objects(muids, org_uid)
 
         async def load():
             nonlocal lines
@@ -137,8 +278,16 @@ class RecordPool:
             threads: List[Future] = []  # : List[Future[List[bytes]]]
             with ThreadPoolExecutor() as executor:
                 for source in sources:
-                    for data_type in ["htop", "spydergraph"]:
-                        threads.append(executor.submit(call_api, data_type, source))
+                    for schema in [
+                        "event_top_data",
+                        "model_process",
+                        "model_connection",
+                        "event_redflag",
+                        "model_listening_socket",
+                        "model_container",
+                    ]:
+                        threads.append(executor.submit(call_api, schema, source))
+                threads.append(executor.submit(fetch_machines, sources))
                 for thread in as_completed(threads):
                     self._process_records(
                         thread.result(), 0.9 / len(threads), parallel=False
@@ -181,33 +330,39 @@ No more records can be loaded."
 
     def _process_records(
         self,
-        lines: Union[List[str], List[bytes]],
+        lines: Union[List[str], List[bytes], List[Record]],
         progress_increase: float,
         parallel=True,
     ) -> None:
         """Process the loaded records, parsing them and adding them to the model"""
+        records: List[Record] | None = None
 
         # if lines is binary, convert to text
         if len(lines) > 0 and isinstance(lines[0], bytes):
             str_lines = [line.decode("utf-8") for line in lines]  # type: ignore
+        if len(lines) > 0 and isinstance(lines[0], dict):
+            records = lines  # type: ignore
+            str_lines = []
         else:
             str_lines: List[str] = lines  # type: ignore
-        lines = [line for line in str_lines if len(line.strip()) != 0]
 
-        if len(lines) == 0:
-            log.info("No records to process")
-            self.progress += progress_increase
-            return
+        if records is None:
+            lines = [line for line in str_lines if len(line.strip()) != 0]
 
-        # translate the lines from json to a dict in parallel
+            if len(lines) == 0:
+                log.info("No records to process")
+                self.progress += progress_increase
+                return
 
-        # for some reason, forking seems to break stdin/out in some cases
-        if parallel:
-            multiprocessing.set_start_method("spawn")
-            with multiprocessing.Pool() as pool:
-                records = pool.map(orjson.loads, lines)
-        else:
-            records = [orjson.loads(line) for line in lines]
+            # translate the lines from json to a dict in parallel
+
+            # for some reason, forking seems to break stdin/out in some cases
+            if parallel:
+                multiprocessing.set_start_method("spawn")
+                with multiprocessing.Pool() as pool:
+                    records = pool.map(orjson.loads, lines)
+            else:
+                records = [orjson.loads(line) for line in lines]
 
         self.progress += 0.5 * progress_increase
 

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -124,7 +124,7 @@ class RecordPool:
         )
         return results
 
-    def _call_search(
+    def _call_search( # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         schema: str,
         start_time: float,
@@ -158,8 +158,8 @@ class RecordPool:
                 search_obj,
             )
             raise APIError("Searching for records failed")
-        id = search_obj.get("id")
-        if not id:
+        obj_id = search_obj.get("id")
+        if not obj_id:
             raise APIError("Search returned an invalid ID")
         complete = False
         result_ids: List[str] = []
@@ -202,7 +202,7 @@ class RecordPool:
 
         return self._call_objects(result_ids, org_uid)
 
-    def load_api(  # pylint: disable=too-many-arguments
+    def load_api(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         org_uid: str,
         source_uid: str,
@@ -261,7 +261,7 @@ class RecordPool:
         def call_api(schema: str, src_id: str):
             records = self._call_search(
                 **input_data,
-                query=f"*",
+                query="*",
                 muid=src_id,
                 cluster_uid=cluster_uid,
                 schema=schema,
@@ -369,7 +369,7 @@ No more records can be loaded."
         for record in records:
             self.progress += 1 / len(lines) * progress_increase * 0.5
 
-            short_schema = str(record["schema"]).split(":")[0]
+            short_schema = str(record["schema"]).split(":", maxsplit=1)[0]
 
             group = self.records[short_schema]
             rec_id = str(record["id"])
@@ -401,7 +401,7 @@ No more records can be loaded."
         orgs = [org for org in orgs if org.get("uid") != "defend_the_flag"]
         self.orgs = orgs
 
-    def load_sources(  # pylint: disable=too-many-arguments
+    def load_sources(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         org_uid: str,
         page: Optional[int] = None,

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -369,13 +369,13 @@ No more records can be loaded."
         for record in records:
             self.progress += 1 / len(lines) * progress_increase * 0.5
 
-            short_schema = record["schema"].split(":")[0]
+            short_schema = str(record["schema"]).split(":")[0]
 
             group = self.records[short_schema]
-            rec_id = record["id"]
+            rec_id = str(record["id"])
             if rec_id in group:
                 curr_rec = group[rec_id]
-                if curr_rec["time"] > record["time"]:
+                if not isinstance(curr_rec["time"], float) or not isinstance(record["time"], float) or curr_rec["time"] > record["time"]:
                     # we already have a record with a newer timestamp
                     continue
             group[rec_id] = record

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -77,7 +77,7 @@ class RecordPool:
         self,
         ids: list[str],
         org_uid: str,
-        retry: bool=True,
+        retry: bool = True,
     ) -> List[Record]:
         """
         Calls the objects service to hydrate the given ids into records
@@ -375,7 +375,11 @@ No more records can be loaded."
             rec_id = str(record["id"])
             if rec_id in group:
                 curr_rec = group[rec_id]
-                if not isinstance(curr_rec["time"], float) or not isinstance(record["time"], float) or curr_rec["time"] > record["time"]:
+                if (
+                    not isinstance(curr_rec["time"], float)
+                    or not isinstance(record["time"], float)
+                    or curr_rec["time"] > record["time"]
+                ):
                     # we already have a record with a newer timestamp
                     continue
             group[rec_id] = record

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -191,7 +191,7 @@ class RecordPool:
 
         return self._call_objects(result_ids, org_uid)
 
-    def load_api(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    def load_api(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         org_uid: str,
         source_uid: str,
@@ -294,9 +294,11 @@ class RecordPool:
             if self._output.endswith(".gz"):
                 f = gzip.open(self._output, "wt", encoding="utf-8")
             else:
-                f = open(self._output, "wt", encoding="utf-8")
+                f = open(  # pylint: disable=consider-using-with
+                    self._output, "wt", encoding="utf-8"
+                )
             f.writelines(lines)
-            f.close
+            f.close()
 
         self.loaded = True
         log.debug("Completed loading records")

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -124,7 +124,7 @@ class RecordPool:
         )
         return results
 
-    def _call_search( # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
+    def _call_search(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         schema: str,
         start_time: float,

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -166,7 +166,7 @@ class RecordPool:
         token = None
         while not complete:
             search_page = self.guard_api_call(
-                method="POST", url=f"/api/v1/org/{org_uid}/search/{id}", token=token
+                method="POST", url=f"/api/v1/org/{org_uid}/search/{obj_id}", token=token
             )
             search_page = orjson.loads(search_page)
             if "status" in search_page:
@@ -188,7 +188,7 @@ class RecordPool:
         # get records from objects
         if len(result_ids) == 0:
             log.debug(
-                f"Received no results from search (schema: {schema}, query: {query}, id: {id})"
+                f"Received no results from search (schema: {schema}, query: {query}, id: {obj_id})"
             )
         if schema == "model_process":
             # we want to ensure we have the full graph, so we need to walk up the parents list

--- a/spydertop/recordpool.py
+++ b/spydertop/recordpool.py
@@ -75,7 +75,7 @@ class RecordPool:
 
     def _call_objects(
         self,
-        ids: list[str],
+        ids: List[str],
         org_uid: str,
         retry: bool = True,
     ) -> List[Record]:
@@ -131,8 +131,8 @@ class RecordPool:
         end_time: float,
         org_uid: str,
         query: str,
-        muid: str | None = None,
-        cluster_uid: str | None = None,
+        muid: Union[str, None] = None,
+        cluster_uid: Union[str, None] = None,
     ) -> List[Record]:
         """
         Calls the search API, then fetches the full records from objects,
@@ -335,7 +335,7 @@ No more records can be loaded."
         parallel=True,
     ) -> None:
         """Process the loaded records, parsing them and adding them to the model"""
-        records: List[Record] | None = None
+        records: Optional[List[Record]] = None
 
         # if lines is binary, convert to text
         if len(lines) > 0 and isinstance(lines[0], bytes):

--- a/spydertop/screens/config.py
+++ b/spydertop/screens/config.py
@@ -130,6 +130,10 @@ class ConfigurationFrame(Frame):  # pylint: disable=too-many-instance-attributes
                 import dateparser  # pylint: disable=import-outside-toplevel
 
                 self.state.time = dateparser.parse(context.time)
+                if self.state.time is not None:
+                    self.state.time = self.state.time.astimezone(
+                        get_timezone(config.settings)
+                    )
                 log.log("parsing time:", context, self.state.time)
 
         if self.args.source is not None:

--- a/spydertop/screens/config.py
+++ b/spydertop/screens/config.py
@@ -508,7 +508,7 @@ Once you have a source configured, you can continue.\
         log.debug(self.cache)
         self.build_error("An unexpected error occurred")
 
-    def build_question(  # pylint: disable=too-many-arguments,too-many-locals
+    def build_question(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
         self,
         question: str,
         answers: List[List[str]],
@@ -728,8 +728,7 @@ see the help page for more information.\
             if last_seen_time.year >= 2020:
                 last_seen_time = last_seen_time.replace(tzinfo=timezone.utc)
                 last_seen_time_local = last_seen_time.astimezone(time_zone)
-                if last_seen_time_local < default_time:
-                    default_time = last_seen_time_local
+                default_time = min(default_time, last_seen_time_local)
 
                 def last_seen_button_callback():
                     date.value = last_seen_time_local

--- a/spydertop/screens/config.py
+++ b/spydertop/screens/config.py
@@ -134,7 +134,6 @@ class ConfigurationFrame(Frame):  # pylint: disable=too-many-instance-attributes
                     self.state.time = self.state.time.astimezone(
                         get_timezone(config.settings)
                     )
-                log.log("parsing time:", context, self.state.time)
 
         if self.args.source is not None:
             if "*" in self.args.source:

--- a/spydertop/screens/config.py
+++ b/spydertop/screens/config.py
@@ -446,16 +446,18 @@ Once you have a source configured, you can continue.\
                             "${4}Cluster:",
                             cluster.get("name", "<No Name>"),
                             " ",
-                            pretty_datetime(
-                                datetime.strptime(
-                                    cluster["last_data"],
-                                    "%Y-%m-%dT%H:%M:%SZ",
+                            (
+                                pretty_datetime(
+                                    datetime.strptime(
+                                        cluster["last_data"],
+                                        "%Y-%m-%dT%H:%M:%SZ",
+                                    )
+                                    .replace(tzinfo=timezone.utc)
+                                    .astimezone(tz=get_timezone(self.config.settings))
                                 )
-                                .replace(tzinfo=timezone.utc)
-                                .astimezone(tz=get_timezone(self.config.settings))
-                            )
-                            if "last_data" in cluster
-                            else "",
+                                if "last_data" in cluster
+                                else ""
+                            ),
                             str(
                                 datetime.strptime(
                                     cluster["last_data"],
@@ -860,9 +862,11 @@ see the help page for more information.\
             "${3}Machine:",
             source.get("description", ""),
             " ",
-            pretty_datetime(last_stored_time)
-            if "last_stored_chunk_end_time" in source
-            else "",
+            (
+                pretty_datetime(last_stored_time)
+                if "last_stored_chunk_end_time" in source
+                else ""
+            ),
             str(last_stored_time),
             source.get("uid", ""),
         ]

--- a/spydertop/screens/loading.py
+++ b/spydertop/screens/loading.py
@@ -144,9 +144,11 @@ class LoadingFrame(Frame):
             def guard():
                 try:
                     self._model.load_data(
-                        self._model.state.time.timestamp()
-                        if self._model.state.time
-                        else None,
+                        (
+                            self._model.state.time.timestamp()
+                            if self._model.state.time
+                            else None
+                        ),
                         timedelta(minutes=5),
                     )
                 except Exception as exc:  # pylint: disable=broad-except

--- a/spydertop/screens/loading.py
+++ b/spydertop/screens/loading.py
@@ -63,7 +63,7 @@ class LoadingFrame(Frame):
     data and processing records."""
 
     _model: AppModel
-    _label: Label
+    _label: FuncLabel
 
     def __init__(self, screen: Screen, model: AppModel) -> None:
         # pylint: disable=duplicate-code

--- a/spydertop/screens/loading.py
+++ b/spydertop/screens/loading.py
@@ -13,7 +13,7 @@ from datetime import timedelta
 import re
 from threading import Thread
 from asciimatics.screen import Screen
-from asciimatics.widgets import Frame, Layout, Label
+from asciimatics.widgets import Frame, Layout
 from asciimatics.exceptions import NextScene
 from asciimatics.event import KeyboardEvent
 from spydertop.model import AppModel

--- a/spydertop/screens/main.py
+++ b/spydertop/screens/main.py
@@ -138,9 +138,11 @@ class MainFrame(Frame):  # pylint: disable=too-many-instance-attributes
         )
         header.add_widget(
             FuncLabel(
-                lambda: self._model.get_machine_short_name(self._model.selected_machine)
-                if self._model.selected_machine is not None
-                else ""
+                lambda: (
+                    self._model.get_machine_short_name(self._model.selected_machine)
+                    if self._model.selected_machine is not None
+                    else ""
+                )
             ),
             1,
         )
@@ -156,7 +158,12 @@ class MainFrame(Frame):  # pylint: disable=too-many-instance-attributes
         for machine_id in machines_to_show:
             machine = self._model.machines.get(machine_id)
             if machine is not None:
-                cpu_count = machine["machine_cores"] if "machine_cores" in machine and isinstance(machine["machine_cores"], int) else 0
+                cpu_count = (
+                    machine["machine_cores"]
+                    if "machine_cores" in machine
+                    and isinstance(machine["machine_cores"], int)
+                    else 0
+                )
             else:
                 times = self._model.get_value("cpu_time", machine_id)
                 if times is None:

--- a/spydertop/screens/main.py
+++ b/spydertop/screens/main.py
@@ -156,7 +156,7 @@ class MainFrame(Frame):  # pylint: disable=too-many-instance-attributes
         for machine_id in machines_to_show:
             machine = self._model.machines.get(machine_id)
             if machine is not None:
-                cpu_count = machine["machine_cores"]
+                cpu_count = machine["machine_cores"] if "machine_cores" in machine and isinstance(machine["machine_cores"], int) else 0
             else:
                 times = self._model.get_value("cpu_time", machine_id)
                 if times is None:

--- a/spydertop/screens/main.py
+++ b/spydertop/screens/main.py
@@ -556,7 +556,11 @@ class MainFrame(Frame):  # pylint: disable=too-many-instance-attributes
 
         for record in records.values():
             # exlude records that are not in the selected_machine
-            if "muid" in record and record["muid"] != self._model.selected_machine:
+            if (
+                "muid" in record
+                and self._model.selected_machine is not None
+                and record["muid"] != self._model.selected_machine
+            ):
                 continue
             # determine if the record is visible for this time
             if "valid_from" in record:

--- a/spydertop/screens/main.py
+++ b/spydertop/screens/main.py
@@ -596,7 +596,8 @@ class MainFrame(Frame):  # pylint: disable=too-many-instance-attributes
                 continue
             needed_ids.add(record_id)
 
-        # if we are handling processes as a tree, then we still need closed processes that have children
+        # if we are handling processes as a tree, then we
+        # still need closed processes that have children
         if self._model.settings.tab == "processes" and self._model.settings.tree:
 
             def add_needed_children(branch):

--- a/spydertop/screens/meters.py
+++ b/spydertop/screens/meters.py
@@ -333,9 +333,12 @@ def update_swap(model: AppModel):
 
 def show_uptime(model: AppModel):
     """Generates the string for the uptime meter"""
+    if model.timestamp is None:
+        return ""
     uptime = ", ".join(
         str(timedelta(seconds=model.timestamp - mach["boot_time"]))
         for mach in model.machines.values()
+        if "boot_time" in mach and isinstance(mach["boot_time"], float)
     )
     if len(uptime) == 0:
         return add_palette("  ${{{meter_label}}}Uptime: ${{1,1}}No Data", model)

--- a/spydertop/screens/meters.py
+++ b/spydertop/screens/meters.py
@@ -40,7 +40,7 @@ def sum_disks(disks: Dict[str, Dict[str, int]]) -> Dict[str, int]:
         prev_disk_name = disk_name
         filtered_disks[disk_name] = values
 
-    return sum_element_wise(filtered_disks.values())  # type: ignore
+    return sum_element_wise(filtered_disks.values()) or {}  # type: ignore
 
 
 def get_disk_values(model: AppModel, muid: str):

--- a/spydertop/screens/meters.py
+++ b/spydertop/screens/meters.py
@@ -177,7 +177,7 @@ def show_tasks(model: AppModel):
     if processes == 0:
         task_count = "${1,1}Not Available"
     else:
-        task_count = processes - tasks["kernel_threads"]
+        task_count = processes - tasks.get("kernel_threads", 0)
     running = tasks.get("running", 0)
     kthreads = tasks.get("kernel_threads", 0)
     threads = tasks.get("total_threads", 0) - kthreads

--- a/spydertop/screens/modals.py
+++ b/spydertop/screens/modals.py
@@ -10,7 +10,7 @@ A set of modal frames used for temporary input
 """
 
 import re
-from typing import Callable, Optional
+from typing import Callable, Optional, Type
 from asciimatics.widgets import Frame, Text, Layout, Widget
 from asciimatics.screen import Screen
 from asciimatics.event import KeyboardEvent, MouseEvent
@@ -38,7 +38,7 @@ class InputModal(Frame):
         on_change: Optional[Callable[[Optional[str]], None]] = None,
         on_submit: Optional[Callable[[str], None]] = None,
         on_death: Optional[Callable[[], None]] = None,
-        widget=Text,
+        widget:Type[Widget]=Text,
         **kwargs,
     ) -> None:
         """
@@ -56,7 +56,7 @@ class InputModal(Frame):
         # handle on_change to call with the value
         if on_change:
             self._text_input = widget(
-                on_change=(
+                on_change=( # pyright: ignore [reportCallIssue]
                     lambda: on_change(self._text_input.value)
                     if self._text_input.is_valid
                     else None
@@ -66,9 +66,10 @@ class InputModal(Frame):
         else:
             self._text_input = widget(**kwargs)
 
+        required_height = self._text_input.required_height(0, width)
         super().__init__(
             screen,
-            self._text_input.required_height(0, width) + 2,
+            required_height + 2 if required_height is not None else 2,
             width + 2,
             is_modal=True,
             reduce_cpu=True,
@@ -87,14 +88,14 @@ class InputModal(Frame):
 
         self.fix()
         if value:
-            self._text_input.value = value
+            self._text_input.value = value # pyright: ignore [reportAttributeAccessIssue]
 
     def process_event(self, event):
         assert self.scene is not None
         if isinstance(event, KeyboardEvent):
             if event.key_code == ord("\n") or event.key_code == Screen.KEY_F10:
                 if self._text_input.is_valid:
-                    self._on_submit(self._text_input.value)
+                    self._on_submit(self._text_input.value or "")
                 self.scene.remove_effect(self)
                 self._on_death()
                 return None

--- a/spydertop/screens/modals.py
+++ b/spydertop/screens/modals.py
@@ -38,7 +38,7 @@ class InputModal(Frame):
         on_change: Optional[Callable[[Optional[str]], None]] = None,
         on_submit: Optional[Callable[[str], None]] = None,
         on_death: Optional[Callable[[], None]] = None,
-        widget:Type[Widget]=Text,
+        widget: Type[Widget] = Text,
         **kwargs,
     ) -> None:
         """
@@ -56,10 +56,12 @@ class InputModal(Frame):
         # handle on_change to call with the value
         if on_change:
             self._text_input = widget(
-                on_change=( # pyright: ignore [reportCallIssue]
-                    lambda: on_change(self._text_input.value)
-                    if self._text_input.is_valid
-                    else None
+                on_change=(  # pyright: ignore [reportCallIssue]
+                    lambda: (
+                        on_change(self._text_input.value)
+                        if self._text_input.is_valid
+                        else None
+                    )
                 ),
                 **kwargs,
             )
@@ -88,7 +90,9 @@ class InputModal(Frame):
 
         self.fix()
         if value:
-            self._text_input.value = value # pyright: ignore [reportAttributeAccessIssue]
+            self._text_input.value = (
+                value  # pyright: ignore [reportAttributeAccessIssue]
+            )
 
     def process_event(self, event):
         assert self.scene is not None

--- a/spydertop/screens/modals.py
+++ b/spydertop/screens/modals.py
@@ -29,7 +29,7 @@ class InputModal(Frame):
     _on_submit: Callable[[str], None]
     _on_death: Callable[[], None]
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         screen: Screen,
         value=None,
@@ -90,8 +90,8 @@ class InputModal(Frame):
 
         self.fix()
         if value:
-            self._text_input.value = (
-                value  # pyright: ignore [reportAttributeAccessIssue]
+            self._text_input.value = (  # pyright: ignore [reportAttributeAccessIssue]
+                value
             )
 
     def process_event(self, event):
@@ -123,7 +123,7 @@ class InputModal(Frame):
 class NotificationModal(Frame):
     """A modal frame for displaying a notification"""
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         screen: Screen,
         text: str,

--- a/spydertop/screens/setup.py
+++ b/spydertop/screens/setup.py
@@ -318,7 +318,7 @@ class SetupFrame(Frame):
             if isinstance(widget, Text):
                 widget.value = str(default_getter(self._model))
             else:
-                widget.value = default_getter(self._model)
+                widget.value = default_getter(self._model) # type: ignore
 
         return widget
 

--- a/spydertop/screens/setup.py
+++ b/spydertop/screens/setup.py
@@ -318,7 +318,7 @@ class SetupFrame(Frame):
             if isinstance(widget, Text):
                 widget.value = str(default_getter(self._model))
             else:
-                widget.value = default_getter(self._model) # type: ignore
+                widget.value = default_getter(self._model)  # type: ignore
 
         return widget
 

--- a/spydertop/utils/__init__.py
+++ b/spydertop/utils/__init__.py
@@ -167,7 +167,7 @@ def calculate_widths(screen_width, desired_columns: List[int]) -> List[int]:
 
 
 def sum_element_wise(
-    group: Union[Iterable[Dict[Any, int]], Iterable[List[int]], Iterable[Tuple[int]]]
+    group: Union[Iterable[Dict[Any, int]], Iterable[List[int]], Iterable[Tuple[int]]],
 ):
     """Sums the values of a group of dicts, lists, or tuples, providing an element-wise sum"""
     try:
@@ -230,9 +230,7 @@ def align_with_overflow(
     left_space = (
         0
         if align == Alignment.LEFT
-        else extra_space // 2
-        if align == Alignment.CENTER
-        else extra_space
+        else extra_space // 2 if align == Alignment.CENTER else extra_space
     )
     spaces = " " * left_space
     right_spaces = " " * (extra_space - left_space + 1) if include_padding else ""
@@ -254,11 +252,15 @@ def get_source_name(source: dict) -> str:
 
 def get_machine_short_name(machine: Record) -> str:
     """Get a short name for a machine"""
-    if "cloud_tags" in machine and "Name" in machine["cloud_tags"]:
+    if (
+        "cloud_tags" in machine
+        and isinstance(machine["cloud_tags"], dict)
+        and "Name" in machine["cloud_tags"]
+    ):
         if "k8s" in "".join(list(machine["cloud_tags"].keys())):
-            return "node:" + machine["hostname"]
+            return "node:" + str(machine["hostname"])
         return machine["cloud_tags"]["Name"]
-    return machine["hostname"]
+    return str(machine["hostname"])
 
 
 def obscure_key(key: str) -> str:

--- a/spydertop/utils/__init__.py
+++ b/spydertop/utils/__init__.py
@@ -173,7 +173,7 @@ def sum_element_wise(
     try:
         first = next(iter(group))
     except StopIteration:
-        return type(group)()
+        return None
     if isinstance(first, dict):
         totals = {}
         for values in group:

--- a/spydertop/utils/__init__.py
+++ b/spydertop/utils/__init__.py
@@ -10,7 +10,6 @@ Various utilities for spydertop
 """
 
 from datetime import datetime, timezone
-import os
 from pathlib import Path
 import re
 from typing import (
@@ -171,9 +170,10 @@ def sum_element_wise(
     group: Union[Iterable[Dict[Any, int]], Iterable[List[int]], Iterable[Tuple[int]]]
 ):
     """Sums the values of a group of dicts, lists, or tuples, providing an element-wise sum"""
-    # this type ignore is due to what seems to be an issue with pyright
-    # it should be removed if the issue is fixed
-    first = next(iter(group))  # type: ignore
+    try:
+        first = next(iter(group))
+    except StopIteration:
+        return
     if isinstance(first, dict):
         totals = {}
         for values in group:

--- a/spydertop/utils/__init__.py
+++ b/spydertop/utils/__init__.py
@@ -173,7 +173,7 @@ def sum_element_wise(
     try:
         first = next(iter(group))
     except StopIteration:
-        return
+        return type(group)()
     if isinstance(first, dict):
         totals = {}
         for values in group:

--- a/spydertop/utils/types.py
+++ b/spydertop/utils/types.py
@@ -507,7 +507,7 @@ class ExtendedParser(Parser):
 
     _color_regex = re.compile(COLOR_REGEX)
 
-    def parse(self): # pyright: ignore [reportIncompatibleMethodOverride]
+    def parse(self):  # pyright: ignore [reportIncompatibleMethodOverride]
         if self._state is None or self._state.text is None:
             return
         if self._state.attributes:

--- a/spydertop/utils/types.py
+++ b/spydertop/utils/types.py
@@ -16,7 +16,7 @@ from enum import Enum
 import re
 from textwrap import TextWrapper
 import traceback
-from typing import Dict, List, NewType, Optional, TextIO, Tuple, Union, Any
+from typing import Dict, List, Optional, TextIO, Tuple, Union, Any
 import logging
 
 import click
@@ -25,9 +25,9 @@ from asciimatics.parsers import Parser
 from spydertop.constants import COLOR_REGEX
 
 # custom types for data held in the model
-Tree = NewType("Tree", Dict[str, Optional[Tuple[bool, "Tree"]]])
-RecordInternal = NewType("RecordInternal", Any)
-Record = NewType("Record", Dict[str, RecordInternal])
+Tree = Dict[str, Optional[Tuple[bool, "Tree"]]]
+RecordInternal = Union[str, int, float, list, dict, None]
+Record = Dict[str, RecordInternal]
 
 
 @dataclass
@@ -54,7 +54,7 @@ class Bytes:
 
     value: int
 
-    def __init__(self, value: Union[int, str]):
+    def __init__(self, value: Union[int, float, str]):
         if isinstance(value, str):
             self.value = int(Bytes.parse_bytes(value))
         else:
@@ -507,7 +507,7 @@ class ExtendedParser(Parser):
 
     _color_regex = re.compile(COLOR_REGEX)
 
-    def parse(self):
+    def parse(self): # pyright: ignore [reportIncompatibleMethodOverride]
         if self._state is None or self._state.text is None:
             return
         if self._state.attributes:

--- a/spydertop/utils/types.py
+++ b/spydertop/utils/types.py
@@ -289,7 +289,7 @@ class CustomTextWrapper(TextWrapper):
     line to line.
     """
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         width: int,
         initial_indent: str = "",

--- a/spydertop/widgets/__init__.py
+++ b/spydertop/widgets/__init__.py
@@ -39,7 +39,7 @@ class Padding(Widget):
     def reset(self):
         pass
 
-    def required_height(self, offset, width):
+    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
         return self._height
 
     def update(self, frame_no):
@@ -104,7 +104,7 @@ class FuncLabel(Widget):
     def reset(self):
         pass
 
-    def required_height(self, offset, width):
+    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
         text = self.generator()
         height = 0
         wrapper = CustomTextWrapper(
@@ -163,6 +163,6 @@ class FuncLabel(Widget):
                 offset += 1
 
     @property
-    def value(self):
+    def value(self): # pyright: ignore [reportIncompatibleMethodOverride]
         """The text of the label."""
         return self.generator()

--- a/spydertop/widgets/__init__.py
+++ b/spydertop/widgets/__init__.py
@@ -39,9 +39,9 @@ class Padding(Widget):
     def reset(self):
         pass
 
-    def required_height(
+    def required_height(  # pyright: ignore [reportIncompatibleMethodOverride]
         self, offset, width
-    ):  # pyright: ignore [reportIncompatibleMethodOverride]
+    ):
         return self._height
 
     def update(self, frame_no):
@@ -83,7 +83,7 @@ class FuncLabel(Widget):
         color="label",
         indent="",
         **kwargs,
-    ):  # pylint: disable=too-many-arguments
+    ):  # pylint: disable=too-many-arguments,too-many-positional-arguments
         """
         :param generator: a function which generates the text to display on screen.
             This function is assumed to have no side effects, and can be run often
@@ -106,9 +106,9 @@ class FuncLabel(Widget):
     def reset(self):
         pass
 
-    def required_height(
+    def required_height(  # pyright: ignore [reportIncompatibleMethodOverride]
         self, offset, width
-    ):  # pyright: ignore [reportIncompatibleMethodOverride]
+    ):
         text = self.generator()
         height = 0
         wrapper = CustomTextWrapper(
@@ -155,6 +155,7 @@ class FuncLabel(Widget):
                     line = ColouredText(line, self.parser)
 
                 # finally, the text is drawn
+                # pylint disable=duplicate-code
                 self._frame.canvas.paint(
                     line,
                     self._x,

--- a/spydertop/widgets/__init__.py
+++ b/spydertop/widgets/__init__.py
@@ -39,7 +39,9 @@ class Padding(Widget):
     def reset(self):
         pass
 
-    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
+    def required_height(
+        self, offset, width
+    ):  # pyright: ignore [reportIncompatibleMethodOverride]
         return self._height
 
     def update(self, frame_no):
@@ -104,7 +106,9 @@ class FuncLabel(Widget):
     def reset(self):
         pass
 
-    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
+    def required_height(
+        self, offset, width
+    ):  # pyright: ignore [reportIncompatibleMethodOverride]
         text = self.generator()
         height = 0
         wrapper = CustomTextWrapper(
@@ -137,9 +141,11 @@ class FuncLabel(Widget):
                 left_space = (
                     0
                     if self.align == Alignment.LEFT
-                    else extra_space // 2
-                    if self.align == Alignment.CENTER
-                    else extra_space
+                    else (
+                        extra_space // 2
+                        if self.align == Alignment.CENTER
+                        else extra_space
+                    )
                 )
                 spaces = " " * left_space
                 line = f"{spaces}{line}"
@@ -156,13 +162,15 @@ class FuncLabel(Widget):
                     color,
                     attr,
                     background,
-                    colour_map=line.colour_map  # type: ignore
-                    if hasattr(line, "colour_map")
-                    else None,
+                    colour_map=(
+                        line.colour_map  # type: ignore
+                        if hasattr(line, "colour_map")
+                        else None
+                    ),
                 )
                 offset += 1
 
     @property
-    def value(self): # pyright: ignore [reportIncompatibleMethodOverride]
+    def value(self):  # pyright: ignore [reportIncompatibleMethodOverride]
         """The text of the label."""
         return self.generator()

--- a/spydertop/widgets/form.py
+++ b/spydertop/widgets/form.py
@@ -59,7 +59,7 @@ def value_to_widget(
             validator=validate,
             on_change=lambda: (
                 on_change_wrapper(float(widget.value))
-                if validate(widget.value)
+                if widget.value is not None and validate(widget.value) 
                 else None
             ),
         )
@@ -78,7 +78,7 @@ def value_to_widget(
             validator=validate_int,
             on_change=lambda: (
                 on_change_wrapper(int(widget.value))
-                if validate_int(widget.value)
+                if widget.value is not None and validate_int(widget.value)
                 else None
             ),
         )
@@ -136,7 +136,7 @@ class Form(Layout):
 
     def set_value(self, label: str, value: FormData):
         """Set the value of a form field."""
-        self._widgets[label].value = value
+        self._widgets[label].value = value # type: ignore
         self._data[label] = value
 
     def _on_change(self, label: str, value: FormData):

--- a/spydertop/widgets/form.py
+++ b/spydertop/widgets/form.py
@@ -59,7 +59,7 @@ def value_to_widget(
             validator=validate,
             on_change=lambda: (
                 on_change_wrapper(float(widget.value))
-                if widget.value is not None and validate(widget.value) 
+                if widget.value is not None and validate(widget.value)
                 else None
             ),
         )
@@ -136,7 +136,7 @@ class Form(Layout):
 
     def set_value(self, label: str, value: FormData):
         """Set the value of a form field."""
-        self._widgets[label].value = value # type: ignore
+        self._widgets[label].value = value  # type: ignore
         self._data[label] = value
 
     def _on_change(self, label: str, value: FormData):

--- a/spydertop/widgets/meter.py
+++ b/spydertop/widgets/meter.py
@@ -27,7 +27,7 @@ class Meter(Widget):
 
     total: Optional[float]
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         label: str,
         values: Union[List[float], List[int]],
@@ -64,9 +64,9 @@ class Meter(Widget):
     def reset(self):
         pass
 
-    def required_height(
+    def required_height(  # pyright: ignore [reportIncompatibleMethodOverride]
         self, offset, width
-    ):  # pyright: ignore [reportIncompatibleMethodOverride]
+    ):
         return 1  # meters are always 1-line
 
     def update(self, frame_no):  # pylint: disable=too-many-locals

--- a/spydertop/widgets/meter.py
+++ b/spydertop/widgets/meter.py
@@ -64,7 +64,9 @@ class Meter(Widget):
     def reset(self):
         pass
 
-    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
+    def required_height(
+        self, offset, width
+    ):  # pyright: ignore [reportIncompatibleMethodOverride]
         return 1  # meters are always 1-line
 
     def update(self, frame_no):  # pylint: disable=too-many-locals
@@ -181,7 +183,7 @@ class Meter(Widget):
                     break
 
     @property
-    def value(self): # pyright: ignore [reportIncompatibleMethodOverride]
+    def value(self):  # pyright: ignore [reportIncompatibleMethodOverride]
         """The values of the bar graph."""
         return self._values
 

--- a/spydertop/widgets/meter.py
+++ b/spydertop/widgets/meter.py
@@ -64,7 +64,7 @@ class Meter(Widget):
     def reset(self):
         pass
 
-    def required_height(self, offset, width):
+    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
         return 1  # meters are always 1-line
 
     def update(self, frame_no):  # pylint: disable=too-many-locals
@@ -181,7 +181,7 @@ class Meter(Widget):
                     break
 
     @property
-    def value(self):
+    def value(self): # pyright: ignore [reportIncompatibleMethodOverride]
         """The values of the bar graph."""
         return self._values
 

--- a/spydertop/widgets/table.py
+++ b/spydertop/widgets/table.py
@@ -60,7 +60,7 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
     _vertical_offset: int = 0
     _horizontal_offset: int = 0
 
-    def __init__(  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         state: State,
         settings: Settings,
@@ -170,6 +170,7 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
 
                     to_paint = str(line)
                     # finally, the line is painted.
+                    # pylint: disable=duplicate-code
                     self._frame.canvas.paint(
                         to_paint + " ",
                         self._x + x_offset,
@@ -264,9 +265,9 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
                 return None
         return event
 
-    def required_height(
+    def required_height(  # pyright: ignore [reportIncompatibleMethodOverride]
         self, offset, width
-    ):  # pyright: ignore [reportIncompatibleMethodOverride]
+    ):
         return Widget.FILL_FRAME
 
     def reset(self):
@@ -400,7 +401,7 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
             # the screen is resizing, so don't do anything
             self._vertical_offset = 0
             return
-        if self._state.selected_row < self._vertical_offset:
+        if self._state.selected_row < self._vertical_offset: # pylint: disable=consider-using-min-builtin
             self._vertical_offset = self._state.selected_row
         if self._state.selected_row >= self._vertical_offset + self._h - 1:
             self._vertical_offset = self._state.selected_row - self._h + 2

--- a/spydertop/widgets/table.py
+++ b/spydertop/widgets/table.py
@@ -177,9 +177,11 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
                         color,
                         attr,
                         background,
-                        colour_map=line.colour_map  # type: ignore
-                        if hasattr(line, "colour_map") and has_color
-                        else None,
+                        colour_map=(
+                            line.colour_map  # type: ignore
+                            if hasattr(line, "colour_map") and has_color
+                            else None
+                        ),
                     )
                     x_offset += width + 1
             y_offset += 1
@@ -262,7 +264,9 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
                 return None
         return event
 
-    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
+    def required_height(
+        self, offset, width
+    ):  # pyright: ignore [reportIncompatibleMethodOverride]
         return Widget.FILL_FRAME
 
     def reset(self):
@@ -516,7 +520,7 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
         )
 
     @property
-    def value(self) -> int: # pyright: ignore [reportIncompatibleMethodOverride]
+    def value(self) -> int:  # pyright: ignore [reportIncompatibleMethodOverride]
         """The selected row"""
         return self._state.selected_row
 

--- a/spydertop/widgets/table.py
+++ b/spydertop/widgets/table.py
@@ -401,7 +401,9 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
             # the screen is resizing, so don't do anything
             self._vertical_offset = 0
             return
-        if self._state.selected_row < self._vertical_offset: # pylint: disable=consider-using-min-builtin
+        if (
+            self._state.selected_row < self._vertical_offset
+        ):  # pylint: disable=consider-using-min-builtin
             self._vertical_offset = self._state.selected_row
         if self._state.selected_row >= self._vertical_offset + self._h - 1:
             self._vertical_offset = self._state.selected_row - self._h + 2

--- a/spydertop/widgets/table.py
+++ b/spydertop/widgets/table.py
@@ -184,7 +184,7 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
                     x_offset += width + 1
             y_offset += 1
 
-    def process_event(  # pylint: disable=too-many-return-statements,too-many-branches
+    def process_event(  # pylint: disable=too-many-return-statements,too-many-branches # pyright: ignore [reportIncompatibleMethodOverride]
         self, event
     ):
         if isinstance(event, KeyboardEvent):
@@ -262,7 +262,7 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
                 return None
         return event
 
-    def required_height(self, offset, width):
+    def required_height(self, offset, width): # pyright: ignore [reportIncompatibleMethodOverride]
         return Widget.FILL_FRAME
 
     def reset(self):
@@ -516,7 +516,7 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
         )
 
     @property
-    def value(self) -> int:
+    def value(self) -> int: # pyright: ignore [reportIncompatibleMethodOverride]
         """The selected row"""
         return self._state.selected_row
 

--- a/spydertop/widgets/table.py
+++ b/spydertop/widgets/table.py
@@ -401,9 +401,9 @@ class Table(Widget):  # pylint: disable=too-many-instance-attributes
             # the screen is resizing, so don't do anything
             self._vertical_offset = 0
             return
-        if (
+        if (  # pylint: disable=consider-using-min-builtin
             self._state.selected_row < self._vertical_offset
-        ):  # pylint: disable=consider-using-min-builtin
+        ):
             self._vertical_offset = self._state.selected_row
         if self._state.selected_row >= self._vertical_offset + self._h - 1:
             self._vertical_offset = self._state.selected_row - self._h + 2


### PR DESCRIPTION
This updates Spydertop to use the new Search and Objects APIs instead of source query.

It also fixes issues that have accumulated since the last time Spydertop was updated, mostly due to linters being updated.

## Other Changes

- The model now shows an aggregate view for clusters, instead of silently defaulting to the first machine.
- The default load time is now longer, since the loading time difference is negligible.
- Updated the supported python versions to 3.8-3.13 (the range supported by GitHub Actions). Python 3.8 is actually end-of-life, so we can consider dropping it if necessary.
- Fixed various crashes related to outdated code.
- Addressed many new pyright and pylint issues